### PR TITLE
Add option to hide the "FPS:" label

### DIFF
--- a/FPSPlugin.cs
+++ b/FPSPlugin.cs
@@ -76,7 +76,7 @@ namespace FPSPlugin {
                     var windowInactive = Marshal.ReadByte(framework.Address.BaseAddress, 0x17D0) == 1;
                     if (fps > maxSeenFps) maxSeenFps = fps;
 
-                    fpsText = $"FPS:{FormatFpsValue(fps)}";
+                    fpsText = (PluginConfig.ShowLabel ? "FPS:" : "") + FormatFpsValue(fps);
                     if (PluginConfig.ShowAverage || PluginConfig.ShowMinimum) {
                         if (!windowInactive) fpsHistory.Add(fps);
 

--- a/FPSPluginConfig.cs
+++ b/FPSPluginConfig.cs
@@ -40,6 +40,7 @@ namespace FPSPlugin {
         public bool ShowAverage;
         public bool ShowMinimum;
         public bool MultiLine;
+        public bool ShowLabel = true; 
 
         public FPSPluginFont Font = FPSPluginFont.PluginDefault;
         
@@ -82,6 +83,7 @@ namespace FPSPlugin {
             changed |= ImGui.Checkbox("Show Decimals##fpsPluginDecimalsSetting", ref ShowDecimals);
             changed |= ImGui.Checkbox("Show Average##fpsPluginShowAverageSetting", ref ShowAverage);
             changed |= ImGui.Checkbox("Show Minimum##fpsPluginShowMinimumSetting", ref ShowMinimum);
+            changed |= ImGui.Checkbox("Show \"FPS\" label##fpsPluginShowLabel", ref ShowLabel);
             changed |= ImGui.Checkbox("Multiline##fpsPluginMultiline", ref MultiLine);
             changed |= ImGui.InputInt("Tracking Timespan (Seconds)", ref HistorySnapshotCount, 1, 60);
 


### PR DESCRIPTION
I implemented an option to hide the "FPS:" prefix on the label.

The new config item is on by default.

![image](https://user-images.githubusercontent.com/2473314/148955867-52588c93-c59b-4ece-b1cc-04ff2357595f.png)

I needed this to do this:
![image](https://user-images.githubusercontent.com/2473314/148955970-517ab2fb-3bf9-404c-9432-937ffc1b604e.png)

I believe this closes #2 too :p.